### PR TITLE
feat/password-criteria

### DIFF
--- a/src/main/java/com/zweaver/statistics/config/BasicAuthConfig.java
+++ b/src/main/java/com/zweaver/statistics/config/BasicAuthConfig.java
@@ -27,7 +27,11 @@ public class BasicAuthConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
-            .antMatchers("/api/v1/uploadFile").authenticated()
+            .antMatchers("/api/v1/createUser").permitAll()
+            .antMatchers("/api/v1/login").permitAll()
+            .and()
+            .authorizeRequests()
+            .anyRequest().authenticated()
             .and()
             .csrf().disable().httpBasic();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/statdb
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.username=postgres
+spring.datasource.password=NeuralNet1
 
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 


### PR DESCRIPTION
Implemented password criteria method, changed @RequestParam to @RequestHeader for fetching username/password, now properly permitting /createUser and /login (which previously required you to be authenticated)