### PR TITLE
overwriteData(), Messages class, nullpointer in viewData (#14)

### DIFF
--- a/src/main/java/com/zweaver/statistics/controller/FileUploadController.java
+++ b/src/main/java/com/zweaver/statistics/controller/FileUploadController.java
@@ -70,9 +70,10 @@ public class FileUploadController {
     }
 
     @GetMapping("/viewData")
-    public @ResponseBody DataSet viewFile(@RequestParam("filename") String filename,
+    public @ResponseBody Object viewFile(@RequestParam("filename") String filename,
             @CurrentSecurityContext(expression = "authentication?.name") String username) {
         FileStorageEntity file = fileStorageRepository.findByUsernameAndFilename(username, filename);
+        if (file == null) { return new ResponseEntity<>("Could not find requested file.", HttpStatus.BAD_REQUEST); }
         return file.getDataSet();
     }
 

--- a/src/main/java/com/zweaver/statistics/msg/Messages.java
+++ b/src/main/java/com/zweaver/statistics/msg/Messages.java
@@ -1,0 +1,5 @@
+package com.zweaver.statistics.msg;
+
+public class Messages {
+    public static final String couldNotFindRequestedFile = "Could not find requested file.";
+}


### PR DESCRIPTION
Users can now overwrite data sets. Created Messages class when returning frequent/common messages. Fixed null pointer exception in /viewData when data was not found in repository.